### PR TITLE
Changed yarn test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --ci --testFailureExitCode 1 --watchAll=false",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,6 +3,6 @@ import App from './App';
 
 test('renders learn react link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement; = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
 });


### PR DESCRIPTION
Added some args `--testFailureExitCode 1` to set the error code when a
test fails and `--watchAll=false` to make the test non-interactive. This
later addtion could be removed as the tests must have run fine before
but made my exprience nicer.

Tests didn't pass on the commit due to what looked like networking error in trying to get the deps. I am assuming this will sort it's self out and was not related to my code changes.

I did some looking and while yarn does report non-zero exit codes it on the things it runs jest does not report an error code by default for failing tests.